### PR TITLE
Serverless function fix

### DIFF
--- a/cloudfunc/ycfunc.go
+++ b/cloudfunc/ycfunc.go
@@ -331,18 +331,6 @@ func createBackupRequest(target string) bool {
 		return false
 	}
 
-	hasBackup, err := bkpr.IsBackupCreated()
-
-	if err != nil {
-		log.Error("Can't check backup status: %v", err)
-		return false
-	}
-
-	if hasBackup {
-		log.Info("Backup already created, nothing to do")
-		return true
-	}
-
 	taskID, err := bkpr.Start()
 
 	if err != nil {

--- a/common/atlassian-cloud-backuper.spec
+++ b/common/atlassian-cloud-backuper.spec
@@ -110,5 +110,12 @@ rm -rf %{buildroot}
 ################################################################################
 
 %changelog
+* Thu Apr 04 2024 Anton Novojilov <andy@essentialkaos.com> - 0.0.2-0
+- Added cloud/serverless function for Yandex.Cloud
+- Fixed bug with handling STORAGE_S3_REGION value from options and environment
+  variables
+- Code refactoring
+- Dependencies update
+
 * Tue Mar 26 2024 Anton Novojilov <andy@essentialkaos.com> - 0.0.1-0
 - Initial build for kaos-repo


### PR DESCRIPTION
### What did you implement:

Removed the existing backup check because it was impossible to use with the Confluence API.

### How did you implement it:

Check removed.
